### PR TITLE
make role and tests python 3 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ sudo: required
 dist: trusty
 
 language: python
-python: "3.6"
+python:
+  - 2.7
+  - 3.6
 
 env:
   - SITE=test.yml ANSIBLE_VERSION=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: trusty
 
 language: python
-python: "2.7"
+python: "3.6"
 
 env:
   - SITE=test.yml ANSIBLE_VERSION=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python: "3.6"
 
 env:
   - SITE=test.yml ANSIBLE_VERSION=latest
-  - SITE=test.yml ANSIBLE_VERSION=2.1.0.0
+  - SITE=test.yml ANSIBLE_VERSION=2.2
 
 branches:
   only:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   description: Installs exim4 (sendonly) on Debian/Ubuntu linux servers.
   company: ambimax® GmbH
   license: MIT
-  min_ansible_version: 2.1
+  min_ansible_version: 2.2
   platforms:
   - name: Debian
     versions:

--- a/templates/email-addresses.j2
+++ b/templates/email-addresses.j2
@@ -1,3 +1,3 @@
-{% for user, email in exim4_sendonly_email_addresses.iteritems() %}
+{% for user, email in exim4_sendonly_email_addresses.items() %}
 {{ user }}: {{ email }}
 {% endfor %}


### PR DESCRIPTION
fixes an error at the email-addresses template.
the ansible run fails here on python 3 with the message:
`"AnsibleUndefinedVariable: 'dict object' has no attribute 'iteritems'"`