### PR TITLE
remove legacy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,16 @@ $ ansible-galaxy install tschifftner.exim4-sendonly
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
 ```
- exim4_sendonly_hostname: '{{ ansible_hostname }}'
- 
  exim4_sendonly_email_addresses:
    root: 'your@email.com'
 ```
 
 The playbook could look like:
-    
+
     - hosts: webservers
-    
+
       roles:
          - { role: tschifftner.exim4-sendonly }
-
 
 ## Use Smart Proxy
 
@@ -51,17 +48,19 @@ exim4_sendonly_password: ''
 ### Set reverse dns for ipv6
 
 Figure out your ipv6 address
+
 ```
 ifconfig eth0
 ```
 
-Use the ip addresses that ends with ```::2/64 Scope:Global```
+Use the ip addresses that ends with `::2/64 Scope:Global`
 
 Also add AAAA Record for this IPv6 address!
 
 ### Set SPF records
 
 TXT Record for Domain
+
 ```
 v=spf1 a mx -all
 v=spf1 a mx a:{{ ansible_fqdn }} -all
@@ -70,27 +69,31 @@ v=spf1 a mx a:{{ ansible_fqdn }} -all
 ### Exim commands
 
 Summary of all emails
+
 ```
 mailq | exiqsumm
 ```
 
 Print a list of messages in the queue
+
 ```
 exim -bp
 ```
 
 Remove single message
+
 ```
 exim -Mrm {message-id}
 ```
 
 Delete all messages from queue
+
 ```
 exim -bp | awk '/^ *[0-9]+[mhd]/{print "exim -Mrm " $3}' | bash
 ```
 
 ## Test email sending
-      
+
 ```
 echo "This is a testmail." | mail -s "Testmail" root
 echo "This is a testmail." | mail -s "Testmail" your@email.com
@@ -98,9 +101,9 @@ echo "This is a testmail." | mail -s "Testmail" your@email.com
 
 ## Supported OS
 
-Ansible          | Debian Jessie    | Ubuntu 14.04    | Ubuntu 12.04
-:--------------: | :--------------: | :-------------: | :-------------: 
-2.1           | Yes              | Yes             | Yes
+| Ansible | Debian Jessie | Ubuntu 14.04 | Ubuntu 12.04 |
+| :-----: | :-----------: | :----------: | :----------: |
+|   2.1   |      Yes      |     Yes      |     Yes      |
 
 ## License
 
@@ -108,4 +111,4 @@ Ansible          | Debian Jessie    | Ubuntu 14.04    | Ubuntu 12.04
 
 ## Author Information
 
- - [Tobias Schifftner](https://twitter.com/tschifftner), [ambimax® GmbH](https://www.ambimax.de)
+*   [Tobias Schifftner](https://twitter.com/tschifftner), [ambimax® GmbH](https://www.ambimax.de)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
 exim4_sendonly_fqdn: '{{ ansible_fqdn }}'
-exim4_sendonly_hostname: '{{ ansible_hostname }}'
 
 exim4_sendonly_enable_tls: true
 exim4_sendonly_smarthost: ''

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,7 +4,6 @@
 
   vars:
     exim4_sendonly_fqdn: 'travis.local'
-    exim4_sendonly_hostname: 'travis.local'
     exim4_sendonly_email_addresses:
       root: 'root@travis.local'
 


### PR DESCRIPTION
Variable *exim4_sendonly_hostname* is defined as a settings but is not used into any file.

This PR remove this settings from documentation and default settings.